### PR TITLE
Soppressioni vulnerabilita' allineate alla convenzione GovPay

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -150,6 +150,8 @@ jobs:
         .
         --lockfile
         ./pom.xml
+        --config
+        ./src/main/resources/osv/falsePositives/osv-scanner.toml
         --allow-no-lockfiles
 
   # ── SBOM CycloneDX ───────────────────────────────────────────────────

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+2026-08-19  Giuliano Pintori <pintori@link.it>
+
+	* [Sicurezza]
+	Riorganizzate le soppressioni delle vulnerabilita' secondo la convenzione
+	degli altri progetti GovPay (govpay-aca-batch, govpay-console-api,
+	govpay-gde-api, govpay-portal-api, govpay-stampe-api):
+	- il file dependency-check-suppressions.xml in root e' stato sostituito da
+	  un file per CVE sotto src/main/resources/owasp/falsePositives/
+	  (CVE-2026-14683.xml, CVE-2026-14686.xml, HdrHistogram 2.2.2);
+	- aggiunta la proprieta' owasp.falsePositives.dir nel pom e aggiornata la
+	  configurazione suppressionFiles del plugin dependency-check-maven;
+	- aggiunto src/main/resources/osv/falsePositives/osv-scanner.toml con le
+	  stesse decisioni per OSV-Scanner, passato al job osv-scan della pipeline
+	  tramite --config.
+
 2026-07-24  Giuliano Pintori <pintori@link.it>
 
 	* [Release]

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
 
     <properties>
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <!-- OWASP: directory dei falsi positivi / vulnerabilita' non applicabili (un file per CVE) -->
+        <owasp.falsePositives.dir>src/main/resources/owasp/falsePositives</owasp.falsePositives.dir>
     </properties>
 
     <dependencies>
@@ -242,6 +244,13 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
+                <configuration>
+                    <!-- Soppressioni locali: vedi le note nei singoli file per il dettaglio e le condizioni di revisione -->
+                    <suppressionFiles>
+                        <suppressionFile>${owasp.falsePositives.dir}/CVE-2026-14683.xml</suppressionFile>
+                        <suppressionFile>${owasp.falsePositives.dir}/CVE-2026-14686.xml</suppressionFile>
+                    </suppressionFiles>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/resources/osv/falsePositives/osv-scanner.toml
+++ b/src/main/resources/osv/falsePositives/osv-scanner.toml
@@ -1,0 +1,17 @@
+# OSV-Scanner: falsi positivi / vulnerabilita' non applicabili.
+# Passato al job osv-scan della pipeline via --config (.github/workflows/maven.yml).
+# Le stesse decisioni sono documentate, per OWASP Dependency-Check, in
+# src/main/resources/owasp/falsePositives/<CVE>.xml
+#
+# Nota: alla data del 2026-08-19 il database OSV non associa queste due CVE al package
+# Maven org.hdrhistogram:HdrHistogram (record CVE senza affected package), quindi
+# osv-scanner non le segnala. Le regole sono preventive, per il caso in cui venga
+# pubblicato un advisory GHSA con mapping sull'ecosistema Maven.
+
+[[IgnoredVulns]]
+id = "CVE-2026-14683"
+reason = "Non applicabile e non risolvibile: HdrHistogram 2.2.2 e' l'ultima versione pubblicata (nessuna release con il fix) e arriva transitivamente da micrometer-core in scope runtime. CVE disputed/Deferred su NVD, CVSS 3.3 LOW con vettore AV:L (accesso locale). La libreria e' usata solo dalle metriche interne di Micrometer, non decodifica istogrammi serializzati provenienti dall'esterno."
+
+[[IgnoredVulns]]
+id = "CVE-2026-14686"
+reason = "Non applicabile e non risolvibile: stessa libreria e stesso contesto di CVE-2026-14683. HdrHistogram 2.2.2 e' l'ultima versione pubblicata, dipendenza transitiva runtime di micrometer-core. CVE disputed/Deferred su NVD, CVSS 3.3 LOW con vettore AV:L. Impatto limitato all'accuratezza delle metriche interne."

--- a/src/main/resources/owasp/falsePositives/CVE-2026-14683.xml
+++ b/src/main/resources/owasp/falsePositives/CVE-2026-14683.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        CVE-2026-14683 (CVSS 3.1: 3.3 LOW, AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N): allocazione di
+        memoria non controllata in org.HdrHistogram.AbstractHistogram.decodeFromCompressedByteBuffer
+        tramite l'argomento lengthOfCompressedContents. L'attacco richiede accesso locale.
+        Soppresso perche' non risolvibile e non applicabile: la 2.2.2 e' l'ultima versione pubblicata
+        su Maven Central (lastUpdated 2024-05-30) e non esiste una release con il fix. La libreria
+        arriva transitivamente da micrometer-core, che la dichiara in scope runtime con versione
+        fissata a 2.2.2; escluderla romperebbe il supporto agli istogrammi a percentili di Micrometer.
+        Nessun percorso di questa libreria decodifica istogrammi serializzati provenienti
+        dall'esterno: HdrHistogram e' usata solo dalle metriche interne di Micrometer.
+        La segnalazione e' contestata (disputed) dal vendor su NVD, in stato Deferred.
+        Non ha CPE applicability statement su NVD, quindi non viene associata al jar dall'analyzer
+        NVD: arriva dall'analyzer OSS Index (owasp.ossindex.analyzer.enabled=true). Per robustezza
+        la regola matcha sia come <cve> sia come <vulnerabilityName>, dato che il nome della
+        segnalazione dipende dalla sorgente che la riporta.
+        Riferimenti: https://api.osv.dev/v1/vulns/CVE-2026-14683
+        Rivedere se HdrHistogram pubblica una nuova versione o se il punteggio CVE viene rivisto
+        al rialzo.
+        Data analisi: 2026-08-19
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.hdrhistogram/HdrHistogram@.*$</packageUrl>
+        <cve>CVE-2026-14683</cve>
+        <vulnerabilityName>CVE-2026-14683</vulnerabilityName>
+    </suppress>
+</suppressions>

--- a/src/main/resources/owasp/falsePositives/CVE-2026-14686.xml
+++ b/src/main/resources/owasp/falsePositives/CVE-2026-14686.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        CVE-2026-14686 (CVSS 3.1: 3.3 LOW, AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N): confronto errato
+        nel range check di org.HdrHistogram.DoubleHistogram.recordValue. L'attacco e' possibile
+        solo con accesso locale. Stessa libreria e stesso contesto di CVE-2026-14683.
+        Soppresso perche' non risolvibile e non applicabile: la 2.2.2 e' l'ultima versione pubblicata
+        su Maven Central (lastUpdated 2024-05-30) e non esiste una release con il fix. La libreria
+        arriva transitivamente da micrometer-core, che la dichiara in scope runtime con versione
+        fissata a 2.2.2; escluderla romperebbe il supporto agli istogrammi a percentili di Micrometer.
+        L'impatto e' limitato all'accuratezza delle metriche interne, senza effetti sui dati
+        applicativi o sui pagamenti.
+        La segnalazione e' contestata (disputed) dal vendor su NVD, in stato Deferred.
+        Non ha CPE applicability statement su NVD, quindi non viene associata al jar dall'analyzer
+        NVD: arriva dall'analyzer OSS Index (owasp.ossindex.analyzer.enabled=true). Per robustezza
+        la regola matcha sia come <cve> sia come <vulnerabilityName>, dato che il nome della
+        segnalazione dipende dalla sorgente che la riporta.
+        Riferimenti: https://api.osv.dev/v1/vulns/CVE-2026-14686
+        Rivedere se HdrHistogram pubblica una nuova versione o se il punteggio CVE viene rivisto
+        al rialzo.
+        Data analisi: 2026-08-19
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.hdrhistogram/HdrHistogram@.*$</packageUrl>
+        <cve>CVE-2026-14686</cve>
+        <vulnerabilityName>CVE-2026-14686</vulnerabilityName>
+    </suppress>
+</suppressions>


### PR DESCRIPTION
## Contesto

Le soppressioni dei falsi positivi di OWASP Dependency-Check stavano in un unico file `dependency-check-suppressions.xml` nella root del progetto. Gli altri progetti della famiglia GovPay (`govpay-aca-batch`, `govpay-console-api`, `govpay-gde-api`, `govpay-portal-api`, `govpay-stampe-api`) usano invece una convenzione diversa: un file per CVE sotto `src/main/resources/owasp/falsePositives/`, referenziato tramite la proprietà `owasp.falsePositives.dir`.

## Modifiche

- `dependency-check-suppressions.xml` sostituito da un file per CVE sotto `src/main/resources/owasp/falsePositives/`:
  - `CVE-2026-14683.xml` — allocazione di memoria non controllata in `AbstractHistogram.decodeFromCompressedByteBuffer`
  - `CVE-2026-14686.xml` — confronto errato nel range check di `DoubleHistogram.recordValue`

  Entrambe riguardano HdrHistogram 2.2.2, dipendenza transitiva runtime di `micrometer-core`. Le note seguono il formato usato negli altri progetti: descrizione, CVSS e vettore, motivazione della non applicabilità, assenza di versione con il fix, riferimenti e data analisi. Mantenuto il doppio match `<cve>`/`<vulnerabilityName>`, necessario perché le segnalazioni arrivano dall'analyzer OSS Index e non da NVD (non hanno CPE applicability statement).
- Aggiunta la proprietà `owasp.falsePositives.dir` nel `pom.xml` e aggiornata la configurazione `suppressionFiles` del plugin `dependency-check-maven`.
- Aggiunto `src/main/resources/osv/falsePositives/osv-scanner.toml` con le stesse decisioni per OSV-Scanner, passato al job `osv-scan` della pipeline tramite `--config` (come in `govpay-stampe-api`). Prima le due CVE erano soppresse per OWASP ma non per OSV.
- Entry nel `ChangeLog` sotto `[Sicurezza]`.

## Nota sul lato OSV

Interrogando `api.osv.dev`, i record `CVE-2026-14683` e `CVE-2026-14686` esistono ma sono record CVE puri, senza `affected package` e senza alias GHSA; la query per `org.hdrhistogram:HdrHistogram@2.2.2` sull'ecosistema Maven non restituisce nulla. Quindi allo stato attuale osv-scanner non segnala queste CVE: le regole nel toml sono preventive, per il caso in cui venga pubblicato un advisory GHSA con mapping sull'ecosistema Maven. La cosa è annotata in testa al file.

## Verifiche

- XML dei due file di soppressione e del `pom.xml` ben formati
- TOML parsato correttamente
- YAML del workflow parsato correttamente
- `mvn help:evaluate -Dexpression=owasp.falsePositives.dir` risolve il percorso atteso

`mvn verify` con dependency-check non è stata eseguita in locale (richiede il download del database NVD): la verifica effettiva avviene in pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)