### PR TITLE
Risolte le 7 segnalazioni Bug di SonarCloud (Reliability)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,37 @@
+2026-08-26  Giuliano Pintori <pintori@link.it>
+
+	* [Bug fix]
+	Risolte le 7 segnalazioni Bug aperte su SonarCloud (Reliability).
+
+	javabugs:S2259 (Blocker) su GdeCapturingInterceptor: il null del body di
+	risposta viene normalizzato alla sorgente, cosi' che non possa raggiungere
+	ne' l'HttpDataHolder ne' il log di trace. Il body assente e' una condizione
+	attesa (204/304, errori remoti senza payload) e l'interceptor non deve mai
+	poter far fallire la chiamata di business che osserva.
+
+	java:S8700 (6 occorrenze) sul sottosistema batch: le durate venivano
+	calcolate tra valori LocalDateTime, che non identificano un istante
+	assoluto. A cavallo delle transizioni di ora legale il risultato era
+	sbagliato di un'ora e, nella notte del ritorno all'ora solare, anche
+	negativo. Introdotta it.govpay.common.utils.DurationUtils, che ancora
+	gli istanti a una ZoneId esplicita prima del calcolo, e applicata a:
+	- JobConcurrencyService.isJobExecutionStale: ora usa un Clock iniettabile
+	  (nuovo costruttore e nuovo factory method in BatchCommonAutoConfiguration,
+	  quelli esistenti restano validi). Il difetto qui incideva sulla logica di
+	  lock: soglia valutata su una durata sbagliata significa doppia esecuzione
+	  del job o job bloccato;
+	- AbstractBatchController: durata dell'esecuzione in corso e dell'ultima
+	  esecuzione, calcolate con la ZoneId applicativa gia' iniettata;
+	- AbstractBatchExecutionListener: durate di job e step, con nuovo metodo
+	  sovrascrivibile getApplicationZoneId(). Le durate con endTime assente
+	  ora valgono zero invece di sollevare NullPointerException.
+
+	* [Test]
+	Aggiunti 17 test: transizioni DST di Europe/Rome (29 marzo e 25 ottobre
+	2026) su DurationUtils, regressione sulla durata dell'ultima esecuzione nel
+	controller, rilevamento stale con Clock fisso a cavallo del cambio d'ora,
+	percorsi senza body sull'interceptor e durate con endTime assente.
+
 2026-08-20  Giuliano Pintori <pintori@link.it>
 
 	* [Release]

--- a/src/main/java/it/govpay/common/batch/config/BatchCommonAutoConfiguration.java
+++ b/src/main/java/it/govpay/common/batch/config/BatchCommonAutoConfiguration.java
@@ -18,6 +18,7 @@
  */
 package it.govpay.common.batch.config;
 
+import java.time.Clock;
 import java.time.ZoneId;
 
 import org.springframework.batch.core.launch.JobOperator;
@@ -83,6 +84,25 @@ public final class BatchCommonAutoConfiguration {
             JobRepository jobRepository,
             BatchJobProperties properties) {
         return new JobConcurrencyService(jobRepository, properties.getStaleThresholdMinutes());
+    }
+
+    /**
+     * Crea un JobConcurrencyService con un orologio esplicito.
+     * <p>
+     * Da preferire quando si vuole legare il rilevamento dei job stale alla zona applicativa
+     * configurata invece che alla zona di default della JVM, o poter iniettare un
+     * {@link Clock} fisso nei test.
+     *
+     * @param jobRepository JobRepository per interrogare e aggiornare lo stato dei job
+     * @param properties Properties di configurazione del batch
+     * @param clock Sorgente dell'ora corrente e della zona applicativa
+     * @return JobConcurrencyService configurato
+     */
+    public static JobConcurrencyService createJobConcurrencyService(
+            JobRepository jobRepository,
+            BatchJobProperties properties,
+            Clock clock) {
+        return new JobConcurrencyService(jobRepository, properties.getStaleThresholdMinutes(), clock);
     }
 
     /**

--- a/src/main/java/it/govpay/common/batch/controller/AbstractBatchController.java
+++ b/src/main/java/it/govpay/common/batch/controller/AbstractBatchController.java
@@ -61,6 +61,7 @@ import it.govpay.common.batch.runner.JobExecutionHelper;
 import it.govpay.common.batch.service.JobConcurrencyService;
 import it.govpay.common.entity.batch.BatchJobExecutionEntity;
 import it.govpay.common.entity.batch.BatchJobExecutionParamEntity;
+import it.govpay.common.utils.DurationUtils;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
@@ -335,7 +336,7 @@ public abstract class AbstractBatchController {
 
         Long runningSeconds = null;
         if (currentExecution.getStartTime() != null) {
-            Duration duration = Duration.between(currentExecution.getStartTime(), LocalDateTime.now(applicationZoneId));
+            Duration duration = DurationUtils.since(currentExecution.getStartTime(), applicationZoneId);
             runningSeconds = duration.getSeconds();
         }
 
@@ -415,10 +416,7 @@ public abstract class AbstractBatchController {
     }
 
     private Long calculateDurationSeconds(LocalDateTime startTime, LocalDateTime endTime) {
-        if (startTime == null || endTime == null) {
-            return null;
-        }
-        return Duration.between(startTime, endTime).getSeconds();
+        return DurationUtils.secondsBetween(startTime, endTime, applicationZoneId);
     }
 
     private String getTruncatedExitDescription(JobExecution execution) {

--- a/src/main/java/it/govpay/common/batch/listener/AbstractBatchExecutionListener.java
+++ b/src/main/java/it/govpay/common/batch/listener/AbstractBatchExecutionListener.java
@@ -18,8 +18,8 @@
  */
 package it.govpay.common.batch.listener;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -30,6 +30,7 @@ import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.listener.JobExecutionListener;
 import org.springframework.batch.core.step.StepExecution;
 
+import it.govpay.common.utils.DurationUtils;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -64,12 +65,31 @@ public abstract class AbstractBatchExecutionListener implements JobExecutionList
      */
     protected abstract String getBatchName();
 
+    /**
+     * Zona con cui interpretare i timestamp delle esecuzioni Spring Batch.
+     * <p>
+     * I metadati di Spring Batch espongono {@link LocalDateTime}, che non identifica un istante
+     * assoluto: la zona serve ad ancorarli prima di calcolare le durate, altrimenti a cavallo
+     * delle transizioni di ora legale i tempi di esecuzione riportati risultano sbagliati di
+     * un'ora.
+     * <p>
+     * L'implementazione di default usa la zona di default della JVM, impostata all'avvio da
+     * {@link it.govpay.common.config.TimezoneConfig} a partire dalla property
+     * {@code spring.jackson.time-zone}. Le sottoclassi che non vogliono dipendere da quel
+     * default possono sovrascrivere il metodo restituendo il bean {@code ZoneId} iniettato.
+     *
+     * @return la zona applicativa da usare per il calcolo delle durate
+     */
+    protected ZoneId getApplicationZoneId() {
+        return ZoneId.systemDefault();
+    }
+
     @Override
     public void beforeJob(JobExecution jobExecution) {
         log.info(SEPARATOR);
         log.info("INIZIO BATCH {}", getBatchName());
         log.info("Job ID: {}", jobExecution.getId());
-        log.info("Avvio: {}", LocalDateTime.now().format(TIME_FORMATTER));
+        log.info("Avvio: {}", LocalDateTime.now(getApplicationZoneId()).format(TIME_FORMATTER));
         log.info(SEPARATOR);
     }
 
@@ -80,12 +100,13 @@ public abstract class AbstractBatchExecutionListener implements JobExecutionList
         log.info(SEPARATOR);
 
         // Statistiche generali
-        Duration duration = Duration.between(
+        Long durataSecondi = DurationUtils.secondsBetween(
                 jobExecution.getStartTime(),
-                jobExecution.getEndTime());
+                jobExecution.getEndTime(),
+                getApplicationZoneId());
 
         log.info("Status finale: {}", jobExecution.getStatus());
-        log.info("Durata totale: {} secondi", duration.getSeconds());
+        log.info("Durata totale: {} secondi", durataSecondi != null ? durataSecondi : "n/d");
         log.info("");
 
         // Statistiche per step (delegato alle sottoclassi)
@@ -120,7 +141,8 @@ public abstract class AbstractBatchExecutionListener implements JobExecutionList
         log.info("Elementi scritti: {}", stepExecution.getWriteCount());
         log.info("Elementi saltati: {}", stepExecution.getSkipCount());
 
-        long durationMs = Duration.between(stepExecution.getStartTime(), stepExecution.getEndTime()).toMillis();
+        long durationMs = DurationUtils.millisBetweenOrZero(
+                stepExecution.getStartTime(), stepExecution.getEndTime(), getApplicationZoneId());
         log.info("Durata: {} ms", durationMs);
         log.info("");
     }
@@ -227,7 +249,8 @@ public abstract class AbstractBatchExecutionListener implements JobExecutionList
             result.totalSkipped += partitionExec.getWriteSkipCount();
             result.totalErrors += partitionExec.getReadSkipCount() + partitionExec.getProcessSkipCount();
 
-            long duration = Duration.between(partitionExec.getStartTime(), partitionExec.getEndTime()).toMillis();
+            long duration = DurationUtils.millisBetweenOrZero(
+                    partitionExec.getStartTime(), partitionExec.getEndTime(), getApplicationZoneId());
             result.totalDuration += duration;
 
             String partitionId = extractPartitionId(partitionExec);

--- a/src/main/java/it/govpay/common/batch/service/JobConcurrencyService.java
+++ b/src/main/java/it/govpay/common/batch/service/JobConcurrencyService.java
@@ -18,9 +18,11 @@
  */
 package it.govpay.common.batch.service;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.springframework.batch.core.BatchStatus;
@@ -28,7 +30,7 @@ import org.springframework.batch.core.ExitStatus;
 import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.repository.JobRepository;
 
-import lombok.RequiredArgsConstructor;
+import it.govpay.common.utils.DurationUtils;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -51,7 +53,6 @@ import lombok.extern.slf4j.Slf4j;
  * Richiede un {@link JobRepository} configurato nel contesto Spring.
  */
 @Slf4j
-@RequiredArgsConstructor
 public class JobConcurrencyService {
 
     /** Nome del parametro job per il cluster ID */
@@ -59,6 +60,37 @@ public class JobConcurrencyService {
 
     private final JobRepository jobRepository;
     private final int staleThresholdMinutes;
+    private final Clock clock;
+
+    /**
+     * Costruisce il service usando l'orologio di sistema con la zona di default della JVM.
+     * <p>
+     * La zona di default e' quella impostata all'avvio da
+     * {@link it.govpay.common.config.TimezoneConfig} a partire dalla property
+     * {@code spring.jackson.time-zone}: coincide quindi con la zona applicativa configurata.
+     * Per rendere la dipendenza dal tempo esplicita e verificabile usare
+     * {@link #JobConcurrencyService(JobRepository, int, Clock)}.
+     *
+     * @param jobRepository         JobRepository per interrogare e aggiornare lo stato dei job
+     * @param staleThresholdMinutes minuti di inattivita' oltre i quali un'esecuzione e' stale
+     */
+    public JobConcurrencyService(JobRepository jobRepository, int staleThresholdMinutes) {
+        this(jobRepository, staleThresholdMinutes, Clock.systemDefaultZone());
+    }
+
+    /**
+     * Costruisce il service con un orologio esplicito.
+     *
+     * @param jobRepository         JobRepository per interrogare e aggiornare lo stato dei job
+     * @param staleThresholdMinutes minuti di inattivita' oltre i quali un'esecuzione e' stale
+     * @param clock                 sorgente dell'ora corrente e della zona con cui interpretare
+     *                              i timestamp di Spring Batch, non null
+     */
+    public JobConcurrencyService(JobRepository jobRepository, int staleThresholdMinutes, Clock clock) {
+        this.jobRepository = jobRepository;
+        this.staleThresholdMinutes = staleThresholdMinutes;
+        this.clock = Objects.requireNonNull(clock, "clock non puo' essere null");
+    }
 
     /**
      * Controlla e restituisce l'esecuzione corrente del job, se esiste.
@@ -116,8 +148,12 @@ public class JobConcurrencyService {
         if (status == BatchStatus.STARTED) {
             LocalDateTime lastUpdated = jobExecution.getLastUpdated();
             if (lastUpdated != null) {
-                LocalDateTime now = LocalDateTime.now();
-                Duration duration = Duration.between(lastUpdated, now);
+                // lastUpdated e' un LocalDateTime scritto da Spring Batch: va ancorato alla zona
+                // del clock prima di misurare l'inattivita', altrimenti a cavallo di una
+                // transizione di ora legale la soglia viene valutata su una durata sbagliata di
+                // un'ora, con il rischio di considerare scaduto un lock ancora valido (doppia
+                // esecuzione del job) o valido un lock scaduto (job bloccato).
+                Duration duration = DurationUtils.since(lastUpdated, clock);
                 long minutesSinceLastUpdate = duration.toMinutes();
 
                 if (minutesSinceLastUpdate > staleThresholdMinutes) {
@@ -155,7 +191,7 @@ public class JobConcurrencyService {
 
             // Aggiorna lo stato a FAILED e imposta end time
             jobExecution.setStatus(BatchStatus.FAILED);
-            jobExecution.setEndTime(LocalDateTime.now());
+            jobExecution.setEndTime(LocalDateTime.now(clock));
             jobExecution.setExitStatus(ExitStatus.FAILED
                 .addExitDescription("Job abbandonato automaticamente: non aggiornato da oltre "
                     + staleThresholdMinutes + " minuti o stato anomalo"));
@@ -166,7 +202,7 @@ public class JobConcurrencyService {
                     log.info("Abbandono StepExecution: {} (stato: {})",
                         stepExecution.getStepName(), stepExecution.getStatus());
                     stepExecution.setStatus(BatchStatus.FAILED);
-                    stepExecution.setEndTime(LocalDateTime.now());
+                    stepExecution.setEndTime(LocalDateTime.now(clock));
                     stepExecution.setExitStatus(ExitStatus.FAILED
                         .addExitDescription("Step abbandonato: job stale"));
                     jobRepository.update(stepExecution);
@@ -209,7 +245,7 @@ public class JobConcurrencyService {
 
             // Aggiorna lo stato a ABANDONED e imposta end time
             jobExecution.setStatus(BatchStatus.ABANDONED);
-            jobExecution.setEndTime(LocalDateTime.now());
+            jobExecution.setEndTime(LocalDateTime.now(clock));
             jobExecution.setExitStatus(ExitStatus.STOPPED
                 .addExitDescription("Job terminato forzatamente: " + reason));
 
@@ -219,7 +255,7 @@ public class JobConcurrencyService {
                     log.info("Terminazione forzata StepExecution: {} (stato: {})",
                         stepExecution.getStepName(), stepExecution.getStatus());
                     stepExecution.setStatus(BatchStatus.ABANDONED);
-                    stepExecution.setEndTime(LocalDateTime.now());
+                    stepExecution.setEndTime(LocalDateTime.now(clock));
                     stepExecution.setExitStatus(ExitStatus.STOPPED
                         .addExitDescription("Step terminato forzatamente"));
                     jobRepository.update(stepExecution);

--- a/src/main/java/it/govpay/common/client/gde/GdeCapturingInterceptor.java
+++ b/src/main/java/it/govpay/common/client/gde/GdeCapturingInterceptor.java
@@ -137,8 +137,11 @@ public class GdeCapturingInterceptor implements ClientHttpRequestInterceptor {
             HttpDataHolder.setResponseStatusCode(response.getStatusCode());
             HttpDataHolder.setResponseStatusText(response.getStatusText());
 
-            // Read and capture the response body
-            responseBody = StreamUtils.copyToByteArray(response.getBody());
+            // Read and capture the response body. Il risultato viene normalizzato a un array
+            // vuoto: il body assente e' una condizione attesa (risposte 204/304, errori remoti)
+            // e non deve mai propagarsi come null al resto del metodo o al chiamante.
+            byte[] capturedBody = StreamUtils.copyToByteArray(response.getBody());
+            responseBody = capturedBody != null ? capturedBody : new byte[0];
             HttpDataHolder.setResponseBody(responseBody);
 
             log.trace("Captured response data for {} {}: status={}, body={} bytes, headers={}",

--- a/src/main/java/it/govpay/common/utils/DurationUtils.java
+++ b/src/main/java/it/govpay/common/utils/DurationUtils.java
@@ -1,0 +1,143 @@
+/*
+ * GovPay - Porta di Accesso al Nodo dei Pagamenti SPC
+ * http://www.gov4j.it/govpay
+ *
+ * Copyright (c) 2014-2026 Link.it srl (http://www.link.it).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.govpay.common.utils;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Objects;
+
+/**
+ * Calcolo di durate tra istanti espressi come {@link LocalDateTime}.
+ * <p>
+ * {@code LocalDateTime} rappresenta una data/ora "da calendario", priva di riferimento a un
+ * istante assoluto sulla linea del tempo: la differenza tra due valori calcolata con
+ * {@code Duration.between(LocalDateTime, LocalDateTime)} assume che ogni giorno duri
+ * esattamente 24 ore. L'assunzione e' falsa due volte l'anno in {@code Europe/Rome}, alle
+ * transizioni di ora legale, dove produce durate sbagliate di un'ora e - nella notte del
+ * passaggio a ora solare, quando la stessa ora locale si ripete - anche durate negative.
+ * <p>
+ * Questi metodi ancorano ogni valore a una {@link ZoneId} <strong>esplicita</strong> prima di
+ * calcolare la durata, cosi' che il risultato sia la distanza reale tra i due istanti. Vanno
+ * usati ogni volta che gli istanti provengono da una sorgente che espone {@code LocalDateTime}
+ * e non e' modificabile - tipicamente i metadati di Spring Batch
+ * ({@code JobExecution#getStartTime()}, {@code StepExecution#getEndTime()}, ...).
+ * <p>
+ * Per il codice nuovo resta preferibile tipizzare l'istante come {@link java.time.Instant}
+ * (misure tecniche) oppure {@link ZonedDateTime}/{@link java.time.OffsetDateTime} (date/ora
+ * civili) direttamente alla sorgente, evitando la conversione.
+ * <p>
+ * Nota sulle ore ambigue: alla transizione verso l'ora solare la stessa ora locale esiste due
+ * volte. {@link LocalDateTime#atZone(ZoneId)} risolve l'ambiguita' scegliendo in modo
+ * deterministico l'offset precedente (quello dell'ora legale).
+ *
+ * @see java.time.Duration
+ */
+public final class DurationUtils {
+
+    private DurationUtils() {
+        // Utility class
+    }
+
+    /**
+     * Calcola la durata tra due istanti locali ancorandoli alla zona indicata.
+     *
+     * @param start istante iniziale, non null
+     * @param end   istante finale, non null
+     * @param zone  zona con cui interpretare i due istanti, non null
+     * @return la durata reale tra i due istanti
+     * @throws NullPointerException se uno dei parametri e' null
+     */
+    public static Duration between(LocalDateTime start, LocalDateTime end, ZoneId zone) {
+        Objects.requireNonNull(start, "start non puo' essere null");
+        Objects.requireNonNull(end, "end non puo' essere null");
+        Objects.requireNonNull(zone, "zone non puo' essere null");
+        return Duration.between(start.atZone(zone), end.atZone(zone));
+    }
+
+    /**
+     * Variante null-safe di {@link #between(LocalDateTime, LocalDateTime, ZoneId)} che
+     * restituisce i secondi trascorsi.
+     *
+     * @param start istante iniziale, eventualmente null
+     * @param end   istante finale, eventualmente null
+     * @param zone  zona con cui interpretare i due istanti, non null
+     * @return i secondi tra i due istanti, oppure null se almeno uno dei due non e' valorizzato
+     */
+    public static Long secondsBetween(LocalDateTime start, LocalDateTime end, ZoneId zone) {
+        if (start == null || end == null) {
+            return null;
+        }
+        return between(start, end, zone).getSeconds();
+    }
+
+    /**
+     * Variante null-safe di {@link #between(LocalDateTime, LocalDateTime, ZoneId)} che
+     * restituisce i millisecondi trascorsi, azzerandosi quando la durata non e' calcolabile.
+     * <p>
+     * Pensata per le statistiche aggregate, dove un valore assente non deve interrompere
+     * la somma.
+     *
+     * @param start istante iniziale, eventualmente null
+     * @param end   istante finale, eventualmente null
+     * @param zone  zona con cui interpretare i due istanti, non null
+     * @return i millisecondi tra i due istanti, oppure 0 se almeno uno dei due non e' valorizzato
+     */
+    public static long millisBetweenOrZero(LocalDateTime start, LocalDateTime end, ZoneId zone) {
+        if (start == null || end == null) {
+            return 0L;
+        }
+        return between(start, end, zone).toMillis();
+    }
+
+    /**
+     * Calcola la durata trascorsa da un istante locale a ora, nella zona indicata.
+     *
+     * @param start istante iniziale, non null
+     * @param zone  zona con cui interpretare l'istante iniziale e leggere l'ora corrente, non null
+     * @return la durata reale tra l'istante indicato e adesso
+     * @throws NullPointerException se uno dei parametri e' null
+     */
+    public static Duration since(LocalDateTime start, ZoneId zone) {
+        Objects.requireNonNull(start, "start non puo' essere null");
+        Objects.requireNonNull(zone, "zone non puo' essere null");
+        return Duration.between(start.atZone(zone), ZonedDateTime.now(zone));
+    }
+
+    /**
+     * Calcola la durata trascorsa da un istante locale all'ora letta dal {@link Clock} indicato.
+     * <p>
+     * L'istante iniziale viene interpretato nella zona del clock, quindi la sorgente dell'ora
+     * corrente e quella della conversione sono la stessa: e' la forma da preferire nel codice
+     * che prende decisioni sulla base di una durata, perche' rende il tempo iniettabile e
+     * quindi verificabile con {@link Clock#fixed(java.time.Instant, ZoneId)}.
+     *
+     * @param start istante iniziale, non null
+     * @param clock sorgente dell'ora corrente e della zona, non null
+     * @return la durata reale tra l'istante indicato e l'ora del clock
+     * @throws NullPointerException se uno dei parametri e' null
+     */
+    public static Duration since(LocalDateTime start, Clock clock) {
+        Objects.requireNonNull(start, "start non puo' essere null");
+        Objects.requireNonNull(clock, "clock non puo' essere null");
+        return Duration.between(start.atZone(clock.getZone()).toInstant(), clock.instant());
+    }
+}

--- a/src/test/java/it/govpay/common/batch/controller/AbstractBatchControllerTest.java
+++ b/src/test/java/it/govpay/common/batch/controller/AbstractBatchControllerTest.java
@@ -394,6 +394,31 @@ class AbstractBatchControllerTest {
         }
 
         @Test
+        @DisplayName("Esecuzione a cavallo del ritorno all'ora solare - durata reale")
+        void executionAcrossDstTransition() {
+            JobInstance instance = mock(JobInstance.class);
+            JobExecution exec = mock(JobExecution.class);
+            // 25/10/2026: alle 03:00 CEST le lancette tornano alle 02:00 CET.
+            // Tra i due istanti locali sono passate quattro ore reali, non tre.
+            LocalDateTime start = LocalDateTime.of(2026, 10, 25, 1, 30);
+            LocalDateTime end = LocalDateTime.of(2026, 10, 25, 4, 30);
+
+            when(exec.getId()).thenReturn(2L);
+            when(exec.getStatus()).thenReturn(BatchStatus.COMPLETED);
+            when(exec.getStartTime()).thenReturn(start);
+            when(exec.getEndTime()).thenReturn(end);
+            when(exec.getExitStatus()).thenReturn(new ExitStatus("COMPLETED", "OK"));
+            when(exec.getJobParameters()).thenReturn(new JobParametersBuilder().toJobParameters());
+
+            when(jobRepository.getJobInstances(JOB_NAME, 0, 10)).thenReturn(List.of(instance));
+            when(jobRepository.getJobExecutions(instance)).thenReturn(List.of(exec));
+
+            ResponseEntity<LastExecutionInfo> response = controller.testGetLastExecution();
+
+            assertEquals(4 * 3600L, response.getBody().getDurationSeconds());
+        }
+
+        @Test
         @DisplayName("Exit description troncata a 500 caratteri")
         void truncatedExitDescription() {
             JobInstance instance = mock(JobInstance.class);

--- a/src/test/java/it/govpay/common/batch/listener/AbstractBatchExecutionListenerTest.java
+++ b/src/test/java/it/govpay/common/batch/listener/AbstractBatchExecutionListenerTest.java
@@ -71,6 +71,42 @@ class AbstractBatchExecutionListenerTest {
     }
 
     @Test
+    @DisplayName("afterJob a cavallo della transizione DST non solleva eccezioni")
+    void afterJobAcrossDstTransition() {
+        JobExecution jobExecution = mock(JobExecution.class);
+        // 25/10/2026: alle 03:00 CEST le lancette tornano alle 02:00 CET
+        when(jobExecution.getStartTime()).thenReturn(LocalDateTime.of(2026, 10, 25, 1, 30));
+        when(jobExecution.getEndTime()).thenReturn(LocalDateTime.of(2026, 10, 25, 4, 30));
+        when(jobExecution.getStatus()).thenReturn(BatchStatus.COMPLETED);
+
+        assertDoesNotThrow(() -> listener.afterJob(jobExecution));
+    }
+
+    @Test
+    @DisplayName("afterJob con endTime assente non solleva eccezioni")
+    void afterJobSenzaEndTime() {
+        JobExecution jobExecution = mock(JobExecution.class);
+        // Prima della correzione Duration.between(start, null) sollevava NullPointerException
+        // dentro il listener, propagandolo al ciclo di vita del job
+        when(jobExecution.getStartTime()).thenReturn(LocalDateTime.of(2026, 6, 15, 10, 0));
+        when(jobExecution.getEndTime()).thenReturn(null);
+        when(jobExecution.getStatus()).thenReturn(BatchStatus.STARTED);
+
+        assertDoesNotThrow(() -> listener.afterJob(jobExecution));
+    }
+
+    @Test
+    @DisplayName("printSimpleStepStats con endTime assente non solleva eccezioni")
+    void printSimpleStepStatsSenzaEndTime() {
+        StepExecution stepExecution = mock(StepExecution.class);
+        when(stepExecution.getStatus()).thenReturn(BatchStatus.STARTED);
+        when(stepExecution.getStartTime()).thenReturn(LocalDateTime.of(2026, 6, 15, 10, 0));
+        when(stepExecution.getEndTime()).thenReturn(null);
+
+        assertDoesNotThrow(() -> listener.printSimpleStepStats(stepExecution, 1, "step di prova"));
+    }
+
+    @Test
     @DisplayName("afterJob con duration calcolata")
     void afterJob() {
         JobExecution jobExecution = mock(JobExecution.class);

--- a/src/test/java/it/govpay/common/batch/service/JobConcurrencyServiceTest.java
+++ b/src/test/java/it/govpay/common/batch/service/JobConcurrencyServiceTest.java
@@ -21,7 +21,10 @@ package it.govpay.common.batch.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -119,6 +122,24 @@ class JobConcurrencyServiceTest {
         when(execution.getLastUpdated()).thenReturn(LocalDateTime.now().minusMinutes(STALE_THRESHOLD_MINUTES + 10));
 
         assertTrue(service.isJobExecutionStale(execution));
+    }
+
+    @Test
+    @DisplayName("isJobExecutionStale - soglia valutata sulla durata reale attraverso la transizione DST")
+    void isJobExecutionStale_dstTransition() {
+        // Clock fermo alle 03:00 ora locale del 25/10/2026, subito dopo il ritorno all'ora
+        // solare (le lancette sono tornate da 03:00 CEST a 02:00 CET): 02:00 UTC.
+        Clock clock = Clock.fixed(Instant.parse("2026-10-25T02:00:00Z"), ZoneId.of("Europe/Rome"));
+        JobConcurrencyService serviceConClock =
+                new JobConcurrencyService(jobRepository, STALE_THRESHOLD_MINUTES, clock);
+
+        // Ultimo aggiornamento alle 01:30 ora locale, ancora in ora legale: 23:30 UTC del 24.
+        // Sono passati 150 minuti reali, oltre la soglia di 120, mentre la differenza fra le
+        // due ore locali ne conterebbe soltanto 90 e l'esecuzione non risulterebbe stale.
+        JobExecution execution = createMockJobExecution(1L, BatchStatus.STARTED);
+        when(execution.getLastUpdated()).thenReturn(LocalDateTime.of(2026, 10, 25, 1, 30));
+
+        assertTrue(serviceConClock.isJobExecutionStale(execution));
     }
 
     @Test

--- a/src/test/java/it/govpay/common/client/gde/GdeCapturingInterceptorTest.java
+++ b/src/test/java/it/govpay/common/client/gde/GdeCapturingInterceptorTest.java
@@ -25,6 +25,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -277,6 +278,44 @@ class GdeCapturingInterceptorTest {
         // And the captured body should still be available
         assertEquals(responseBody, HttpDataHolder.getResponseBodyAsString());
         assertEquals(responseBody, result);
+
+        mockServer.verify();
+    }
+
+    @Test
+    void testCapturesResponseWithoutBody() {
+        // 204 No Content: il body e' assente. La cattura non deve sollevare eccezioni
+        // (l'interceptor non deve mai far fallire la chiamata di business) e il body
+        // catturato deve essere un array vuoto, non null.
+        mockServer.expect(requestTo("/api/items/1"))
+                .andExpect(method(HttpMethod.DELETE))
+                .andRespond(withStatus(HttpStatus.NO_CONTENT));
+
+        assertDoesNotThrow(() -> restTemplate.delete("/api/items/1"));
+
+        assertEquals(HttpStatus.NO_CONTENT, HttpDataHolder.getResponseStatusCode());
+        assertNotNull(HttpDataHolder.getResponseBody());
+        assertEquals(0, HttpDataHolder.getResponseBody().length);
+        assertEquals("", HttpDataHolder.getResponseBodyAsString());
+
+        mockServer.verify();
+    }
+
+    @Test
+    void testCapturesErrorResponseWithoutBody() {
+        // Servizio remoto in errore senza payload: e' lo scenario "di bordo" in cui
+        // l'interceptor si attiva mentre il sistema e' gia' in difficolta'. Deve
+        // limitarsi a non registrare nulla di piu', senza aggiungere un secondo guasto.
+        mockServer.expect(requestTo("/api/error"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThrows(HttpServerErrorException.class,
+                () -> restTemplate.getForEntity("/api/error", String.class));
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, HttpDataHolder.getResponseStatusCode());
+        assertNotNull(HttpDataHolder.getResponseBody());
+        assertEquals(0, HttpDataHolder.getResponseBody().length);
 
         mockServer.verify();
     }

--- a/src/test/java/it/govpay/common/utils/DurationUtilsTest.java
+++ b/src/test/java/it/govpay/common/utils/DurationUtilsTest.java
@@ -1,0 +1,178 @@
+/*
+ * GovPay - Porta di Accesso al Nodo dei Pagamenti SPC
+ * http://www.gov4j.it/govpay
+ *
+ * Copyright (c) 2014-2026 Link.it srl (http://www.link.it).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3, as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package it.govpay.common.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifica il calcolo delle durate attraverso le due transizioni di ora legale di
+ * {@code Europe/Rome}, dove il calcolo naif su {@link LocalDateTime} sbaglia di un'ora.
+ * <p>
+ * Riferimenti 2026: passaggio a ora legale domenica 29 marzo (02:00 CET -&gt; 03:00 CEST),
+ * ritorno a ora solare domenica 25 ottobre (03:00 CEST -&gt; 02:00 CET).
+ */
+class DurationUtilsTest {
+
+    private static final ZoneId ROMA = ZoneId.of("Europe/Rome");
+
+    @Nested
+    @DisplayName("between - transizioni DST")
+    class Between {
+
+        @Test
+        @DisplayName("passaggio a ora legale: un'ora locale in meno di quella apparente")
+        void oraLegale() {
+            LocalDateTime inizio = LocalDateTime.of(2026, 3, 29, 1, 30);
+            LocalDateTime fine = LocalDateTime.of(2026, 3, 29, 3, 30);
+
+            Duration durata = DurationUtils.between(inizio, fine, ROMA);
+
+            // Le lancette saltano da 02:00 a 03:00: tra i due istanti e' passata una sola ora
+            assertEquals(Duration.ofHours(1), durata);
+            // Il calcolo naif su LocalDateTime ne conterebbe due
+            assertNotEquals(Duration.between(inizio, fine), durata);
+        }
+
+        @Test
+        @DisplayName("ritorno a ora solare: un'ora locale in piu' di quella apparente")
+        void oraSolare() {
+            LocalDateTime inizio = LocalDateTime.of(2026, 10, 25, 1, 30);
+            LocalDateTime fine = LocalDateTime.of(2026, 10, 25, 4, 30);
+
+            Duration durata = DurationUtils.between(inizio, fine, ROMA);
+
+            // Le lancette tornano da 03:00 a 02:00: sono passate quattro ore, non tre
+            assertEquals(Duration.ofHours(4), durata);
+            assertEquals(Duration.ofHours(3), Duration.between(inizio, fine));
+        }
+
+        @Test
+        @DisplayName("ora ambigua risolta sull'offset precedente, durata mai negativa")
+        void oraAmbigua() {
+            // 02:30 del 25 ottobre esiste due volte: atZone sceglie l'offset dell'ora legale
+            LocalDateTime inizio = LocalDateTime.of(2026, 10, 25, 2, 30);
+            LocalDateTime fine = LocalDateTime.of(2026, 10, 25, 2, 45);
+
+            Duration durata = DurationUtils.between(inizio, fine, ROMA);
+
+            assertEquals(Duration.ofMinutes(15), durata);
+            assertTrue(durata.isPositive() || durata.isZero());
+        }
+
+        @Test
+        @DisplayName("intervallo senza transizioni: identico al calcolo naif")
+        void giornoNormale() {
+            LocalDateTime inizio = LocalDateTime.of(2026, 6, 15, 10, 0);
+            LocalDateTime fine = LocalDateTime.of(2026, 6, 15, 10, 5);
+
+            assertEquals(Duration.ofMinutes(5), DurationUtils.between(inizio, fine, ROMA));
+        }
+
+        @Test
+        @DisplayName("parametri null rifiutati")
+        void parametriNull() {
+            LocalDateTime istante = LocalDateTime.of(2026, 6, 15, 10, 0);
+
+            assertThrows(NullPointerException.class, () -> DurationUtils.between(null, istante, ROMA));
+            assertThrows(NullPointerException.class, () -> DurationUtils.between(istante, null, ROMA));
+            assertThrows(NullPointerException.class, () -> DurationUtils.between(istante, istante, null));
+        }
+    }
+
+    @Nested
+    @DisplayName("varianti null-safe")
+    class NullSafe {
+
+        @Test
+        @DisplayName("secondsBetween restituisce null se un estremo manca")
+        void secondsBetween() {
+            LocalDateTime inizio = LocalDateTime.of(2026, 10, 25, 1, 30);
+            LocalDateTime fine = LocalDateTime.of(2026, 10, 25, 4, 30);
+
+            assertEquals(4 * 3600L, DurationUtils.secondsBetween(inizio, fine, ROMA));
+            assertNull(DurationUtils.secondsBetween(null, fine, ROMA));
+            assertNull(DurationUtils.secondsBetween(inizio, null, ROMA));
+        }
+
+        @Test
+        @DisplayName("millisBetweenOrZero azzera se un estremo manca")
+        void millisBetweenOrZero() {
+            LocalDateTime inizio = LocalDateTime.of(2026, 3, 29, 1, 30);
+            LocalDateTime fine = LocalDateTime.of(2026, 3, 29, 3, 30);
+
+            assertEquals(3600_000L, DurationUtils.millisBetweenOrZero(inizio, fine, ROMA));
+            assertEquals(0L, DurationUtils.millisBetweenOrZero(null, fine, ROMA));
+            assertEquals(0L, DurationUtils.millisBetweenOrZero(inizio, null, ROMA));
+        }
+    }
+
+    @Nested
+    @DisplayName("since")
+    class Since {
+
+        @Test
+        @DisplayName("con Clock fisso a cavallo del ritorno all'ora solare")
+        void sinceConClockFisso() {
+            // Il clock e' fermo alle 02:00 CET del 25 ottobre 2026, cioe' 01:00 UTC
+            Clock clock = Clock.fixed(Instant.parse("2026-10-25T01:00:00Z"), ROMA);
+            // Ultimo aggiornamento alle 01:30 ora locale, ancora in ora legale: 23:30 UTC del 24
+            LocalDateTime ultimoAggiornamento = LocalDateTime.of(2026, 10, 25, 1, 30);
+
+            Duration durata = DurationUtils.since(ultimoAggiornamento, clock);
+
+            // Sono passati 90 minuti reali, non 30 come suggerirebbe la differenza delle ore locali
+            assertEquals(90, durata.toMinutes());
+        }
+
+        @Test
+        @DisplayName("con ZoneId esplicita restituisce una durata non negativa")
+        void sinceConZone() {
+            Duration durata = DurationUtils.since(LocalDateTime.now(ROMA).minusMinutes(5), ROMA);
+
+            assertTrue(durata.toMinutes() >= 4 && durata.toMinutes() <= 6,
+                    "durata inattesa: " + durata);
+        }
+
+        @Test
+        @DisplayName("parametri null rifiutati")
+        void parametriNull() {
+            Clock clock = Clock.fixed(Instant.parse("2026-10-25T01:00:00Z"), ROMA);
+
+            assertThrows(NullPointerException.class, () -> DurationUtils.since(null, clock));
+            assertThrows(NullPointerException.class,
+                    () -> DurationUtils.since(LocalDateTime.now(ROMA), (Clock) null));
+            assertThrows(NullPointerException.class,
+                    () -> DurationUtils.since(LocalDateTime.now(ROMA), (ZoneId) null));
+        }
+    }
+}


### PR DESCRIPTION
Chiude le 7 segnalazioni `Bug` aperte su SonarCloud nel perimetro *New Code* (1 `javabugs:S2259` Blocker + 6 `java:S8700` Major), che tenevano il Reliability Rating a **C** e il Quality Gate in **ERROR**.

Due commit distinti: il blocker è indipendente e circoscritto, la rifattorizzazione date/time tocca più file e va letta in modo unitario.

## `070339e` — `javabugs:S2259` (Blocker) in `GdeCapturingInterceptor`

Ho recuperato il *flow* dell'analisi simbolica dall'API di SonarCloud, e la causa non è quella che si immaginerebbe leggendo la riga segnalata. Il motore **deriva** la nullità di `responseBody` dal controllo `body != null` presente in `HttpDataHolder.setResponseBody` (riga 160); con quel vincolo propagato indietro, l'accesso a `responseBody.length` nel log di trace (riga 147) diventa un NPE certo.

Verificato sui sorgenti di Spring 7.0.8 che `StreamUtils.copyToByteArray` **non restituisce mai null** (`return EMPTY_CONTENT` quando lo stream è null): il percorso non è raggiungibile in produzione, ma il codice non lo rendeva dimostrabile all'analizzatore.

Correzione **alla sorgente e non al punto di accesso**: il risultato della copia viene ricondotto a un array vuoto prima di propagarsi all'`HttpDataHolder` e al chiamante. Il body assente è una condizione attesa (204/304, errori remoti senza payload) e non deve attraversare il metodo come null.

Due test sul percorso indicato dal flow — risposta `204 No Content` e risposta `500` senza payload — verificano che la cattura non sollevi eccezioni (l'interceptor non deve poter far fallire la chiamata di business che osserva) e che il body catturato sia vuoto, non null.

## `a7267cf` — `java:S8700` (6 occorrenze) nel sottosistema batch

Le durate erano calcolate con `Duration.between` su valori `LocalDateTime`, tipo che rappresenta una data/ora da calendario e non un istante assoluto: la differenza assume giorni di 24 ore esatte, ipotesi falsa alle due transizioni di ora legale di `Europe/Rome`. Risultato sbagliato di un'ora e, nella notte del ritorno all'ora solare, anche negativo.

Introdotta `it.govpay.common.utils.DurationUtils`, che ancora entrambi gli istanti a una `ZoneId` **esplicita** prima del calcolo, con varianti null-safe (`secondsBetween`, `millisBetweenOrZero`) per i casi in cui Spring Batch non ha ancora valorizzato `endTime`.

| Punto | Intervento |
|---|---|
| `JobConcurrencyService.isJobExecutionStale` | Confermato il sospetto del report: la durata alimenta davvero il ramo decisionale dello stale detection, e usava `LocalDateTime.now()` sulla zona di default della JVM. Ora il servizio riceve un `Clock` iniettabile |
| `AbstractBatchController` (2 punti) | Usa la `ZoneId` applicativa che la classe già riceve in costruzione |
| `AbstractBatchExecutionListener` (3 punti) | La zona è esposta come `protected ZoneId getApplicationZoneId()` sovrascrivibile |

Perché il punto su `JobConcurrencyService` conta: valutare la soglia di stale su una durata sbagliata di un'ora significa considerare scaduto un lock ancora valido (**doppia esecuzione del job** — in ambito GovPay riconciliazioni, notifiche, invii) oppure valido un lock scaduto (**job bloccato** fino a intervento manuale).

## Compatibilità

Nessuna rottura per i progetti consumer:

- `JobConcurrencyService`: il costruttore a 3 argomenti con `Clock` e il nuovo factory method in `BatchCommonAutoConfiguration` sono **affiancati** a quelli esistenti, che restano validi. Il default resta la zona impostata all'avvio da `TimezoneConfig` a partire da `spring.jackson.time-zone`.
- `AbstractBatchExecutionListener`: la classe non ha costruttore ed è estesa dai batch (fdr, aca, notify, ...), quindi la zona è un metodo sovrascrivibile con default, non un parametro nuovo. Le sottoclassi che non vogliono dipendere dal default della JVM possono restituire il bean `ZoneId`.
- Effetto collaterale positivo: le durate con `endTime` assente ora valgono zero invece di sollevare `NullPointerException` dentro il listener.

## Test

**604 test, 0 failure** (da 587: **+17**).

I test DST sono regressioni vere, non tautologie. Sulle transizioni di `Europe/Rome` del 2026 (29 marzo, 25 ottobre), con il codice precedente:

- lo stale detection conterebbe **90 minuti invece di 150** — sotto la soglia di 120, quindi lock erroneamente considerato valido;
- la durata dell'ultima esecuzione esposta dal controller sarebbe **3 ore invece di 4**.

Coperture delle classi toccate: `DurationUtils` 100%, `AbstractBatchExecutionListener` 99,1%, `AbstractBatchController` 94,5%, `GdeCapturingInterceptor` 86,0%.

Checklist §6 del report: `grep` conferma che non resta alcuna occorrenza di `Duration.between`/`ChronoUnit.*.between` su `LocalDateTime`/`LocalDate`/`LocalTime` nel modulo — le sole residue sono dentro `DurationUtils` e operano su `ZonedDateTime`/`Instant`.

## Fuori perimetro

- **Passo 6 del report** (regola ArchUnit anti-ricomparsa): non implementato, introdurrebbe una dipendenza di test nuova ed è meglio deciderlo a parte.
- Se la lettura del body di risposta fallisce con `IOException`, `captureResponseData` logga a WARN e l'interceptor restituisce comunque una risposta bufferizzata **vuota**: il chiamante vede un body assente invece di un errore. È una scelta di non-intrusività preesistente, lasciata invariata perché cambiarla altererebbe il comportamento osservabile; segnalata per decisione separata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)