### PR TITLE
Sonar: risolte 14 delle 15 segnalazioni aperte (2 NPE Blocker, test DST, API deprecate)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,54 @@
 2026-08-26  Giuliano Pintori <pintori@link.it>
 
 	* [Bug fix]
+	Risolte 14 delle 15 segnalazioni SonarCloud rimaste dopo l'analisi delle
+	18:47 (2 Bug Blocker, 2 Bug Major, 10 Code Smell).
+
+	javabugs:S2259 (2 Blocker) su GdeCapturingInterceptor e
+	AbstractBatchController: in entrambi i casi l'analisi simbolica esplora il
+	ramo null di un metodo che ammette null (HttpDataHolder.setResponseBody,
+	JobConcurrencyService.getClusterIdFromExecution) e considera nullo anche
+	l'argomento in ogni accesso successivo alla chiamata. I valori necessari
+	vengono ora letti prima di passare l'oggetto a quei metodi. La correzione
+	precedente sull'interceptor, che normalizzava il null, non era sufficiente:
+	la segnalazione era rimasta aperta.
+
+	java:S2187 e java:S8700 su DurationUtilsTest: la classe usava @Nested, che
+	lasciava l'esterna priva di test eseguibili, e calcolava i valori attesi con
+	Duration.between sugli stessi LocalDateTime, cioe' con un'altra istanza
+	dell'errore che l'utility deve correggere. Struttura resa piatta e valori
+	attesi scritti come costanti esplicite; aggiunto un test DST anche sul
+	passaggio a ora legale.
+
+	java:S1192 su DurationUtils: messaggi di precondition estratti in costanti,
+	uno per parametro, con testo accentato (UTF-8).
+
+	java:S5738 (3 occorrenze): migrate le API Spring Batch marcate
+	@Deprecated(forRemoval = true) dalla 6.0, con rimozione prevista in 6.2.
+	JobExecutionHelper.stopExecution accetta ora una JobExecution e usa
+	JobOperator.stop(JobExecution); AbstractBatchController risolve l'id dal
+	JobRepository e gestisce il 404 esplicitamente, senza la deprecata
+	NoSuchJobExecutionException. Modifica di firma su un metodo pubblico della
+	libreria: nessun consumer noto lo invoca (govpay-console-api chiama
+	l'endpoint REST, non il metodo Java).
+
+	java:S1181 (2 occorrenze) nel sottosistema metriche: ApiTimingMetricsFilter
+	e ExternalCallMetricsRecorder non catturano piu' Error. L'uscita anomala
+	viene rilevata con un flag nel finally, quindi la classificazione dell'esito
+	resta corretta - un Error non viene piu' contato come successo - e la
+	propagazione resta inalterata.
+
+	java:S6213 su ExternalCallMetricsContext: record() rinominato
+	addExternalNanos(), record e' un identificatore riservato. Non applicata la
+	stessa rinomina a ExternalCallMetricsRecorder.record(): il metodo e'
+	sovrascritto da NoopExternalCallMetricsRecorder in govpay-console-api,
+	quindi e' una modifica di contratto da coordinare (BP-API-2).
+
+	java:S2065 (2 occorrenze): rimosso il modificatore transient dai formatter
+	di OffsetDateTimeSerializer e OffsetDateTimeDeserializer, classi che non
+	implementano Serializable.
+
+	* [Bug fix]
 	Risolte le 7 segnalazioni Bug aperte su SonarCloud (Reliability).
 
 	javabugs:S2259 (Blocker) su GdeCapturingInterceptor: il null del body di

--- a/src/main/java/it/govpay/common/batch/controller/AbstractBatchController.java
+++ b/src/main/java/it/govpay/common/batch/controller/AbstractBatchController.java
@@ -38,7 +38,6 @@ import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.JobInstance;
 import org.springframework.batch.core.step.StepExecution;
 import org.springframework.batch.core.launch.JobExecutionNotRunningException;
-import org.springframework.batch.core.launch.NoSuchJobExecutionException;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.core.env.Environment;
 import org.springframework.data.jpa.domain.Specification;
@@ -267,12 +266,17 @@ public abstract class AbstractBatchController {
     }
 
     private ResponseEntity<Object> restituisciJobGiaInEsecuzione(JobExecution currentExecution) {
+        // L'id viene letto prima di passare l'esecuzione a getClusterIdFromExecution: quel
+        // metodo ammette null e l'analisi simbolica, esplorando il suo ramo null, considererebbe
+        // nulla anche questa istanza in ogni accesso successivo (SonarCloud javabugs:S2259).
+        Long executionId = currentExecution.getId();
+
         String runningClusterId = jobExecutionHelper.getJobConcurrencyService().getClusterIdFromExecution(currentExecution);
 
         String detail = String.format(
                 "Il job %s è già in esecuzione (JobExecution ID: %d, Cluster: %s). Usa il parametro force=true per terminarlo forzatamente.",
                 getJobName(),
-                currentExecution.getId(),
+                executionId,
                 runningClusterId);
 
         return problemResponse(Problem.conflict(detail));
@@ -305,13 +309,20 @@ public abstract class AbstractBatchController {
     public ResponseEntity<Object> stopExecution(@PathVariable long executionId) {
         log.info("Richiesta di annullamento della JobExecution {} (batch {})", executionId, getJobName());
 
+        // L'esecuzione viene risolta qui: JobOperator.stop(long) e
+        // NoSuchJobExecutionException sono @Deprecated(forRemoval = true) da Spring Batch 6.0,
+        // con rimozione prevista in 6.2 (SonarCloud java:S5738). L'assenza dell'id diventa un
+        // 404 gestito esplicitamente invece di un'eccezione destinata a sparire.
+        JobExecution execution = jobRepository.getJobExecution(executionId);
+        if (execution == null) {
+            return problemResponse(Problem.notFound("JobExecution " + executionId + " non trovata."));
+        }
+
         try {
-            jobExecutionHelper.stopExecution(executionId);
+            jobExecutionHelper.stopExecution(execution);
             return ResponseEntity.accepted().build();
         } catch (JobExecutionNotRunningException e) {
             return problemResponse(Problem.conflict("La JobExecution " + executionId + " non e' in corso."));
-        } catch (NoSuchJobExecutionException e) {
-            return problemResponse(Problem.notFound("JobExecution " + executionId + " non trovata."));
         }
     }
 

--- a/src/main/java/it/govpay/common/batch/runner/JobExecutionHelper.java
+++ b/src/main/java/it/govpay/common/batch/runner/JobExecutionHelper.java
@@ -31,7 +31,6 @@ import org.springframework.batch.core.launch.JobExecutionAlreadyRunningException
 import org.springframework.batch.core.launch.JobExecutionNotRunningException;
 import org.springframework.batch.core.launch.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.launch.JobRestartException;
-import org.springframework.batch.core.launch.NoSuchJobExecutionException;
 
 import it.govpay.common.batch.TriggerType;
 import it.govpay.common.batch.service.JobConcurrencyService;
@@ -204,14 +203,14 @@ public class JobExecutionHelper {
      * Il processo Java non viene interrotto forzatamente: lo stop resta
      * cooperativo, non immediato.
      *
-     * @param executionId Id della JobExecution da fermare
+     * @param jobExecution la JobExecution da fermare
      * @return true se la richiesta di stop e' stata accettata da Spring Batch
      * @throws JobExecutionNotRunningException se l'esecuzione non e' in corso
-     * @throws NoSuchJobExecutionException se l'id non corrisponde a nessuna esecuzione
      */
-    public boolean stopExecution(long executionId) throws JobExecutionNotRunningException, NoSuchJobExecutionException {
+    public boolean stopExecution(JobExecution jobExecution) throws JobExecutionNotRunningException {
+        Long executionId = jobExecution.getId();
         log.info("Richiesta di stop cooperativo per JobExecution {}", executionId);
-        return jobOperator.stop(executionId);
+        return jobOperator.stop(jobExecution);
     }
 
     /**

--- a/src/main/java/it/govpay/common/client/gde/GdeCapturingInterceptor.java
+++ b/src/main/java/it/govpay/common/client/gde/GdeCapturingInterceptor.java
@@ -142,12 +142,19 @@ public class GdeCapturingInterceptor implements ClientHttpRequestInterceptor {
             // e non deve mai propagarsi come null al resto del metodo o al chiamante.
             byte[] capturedBody = StreamUtils.copyToByteArray(response.getBody());
             responseBody = capturedBody != null ? capturedBody : new byte[0];
+
+            // La dimensione viene letta prima di consegnare l'array all'HttpDataHolder: quel
+            // metodo ammette null e l'analisi simbolica, esplorando il ramo null del callee,
+            // considererebbe nullo anche il nostro array in ogni accesso successivo alla
+            // chiamata (SonarCloud javabugs:S2259).
+            int responseBodyLength = responseBody.length;
+
             HttpDataHolder.setResponseBody(responseBody);
 
             log.trace("Captured response data for {} {}: status={}, body={} bytes, headers={}",
                     request.getMethod(), request.getURI(),
                     response.getStatusCode().value(),
-                    responseBody.length,
+                    responseBodyLength,
                     response.getHeaders().headerNames());
 
         } catch (IOException e) {

--- a/src/main/java/it/govpay/common/metrics/ApiTimingMetricsFilter.java
+++ b/src/main/java/it/govpay/common/metrics/ApiTimingMetricsFilter.java
@@ -76,18 +76,20 @@ public class ApiTimingMetricsFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         long start = System.nanoTime();
-        Throwable error = null;
+        // Uscita anomala rilevata senza catturare l'eccezione: catturare Error terrebbe in vita
+        // una JVM in stato irrecuperabile (SonarCloud java:S1181). Il flag copre qualunque
+        // Throwable, quindi anche gli Error vengono contati come fallimento invece che come
+        // successo, e la propagazione resta inalterata.
+        boolean failed = true;
         try {
             filterChain.doFilter(request, response);
-        } catch (IOException | ServletException | RuntimeException | Error e) {
-            error = e;
-            throw e;
+            failed = false;
         } finally {
             long total = System.nanoTime() - start;
             ExternalCallMetricsContext context = contextProvider.getIfAvailable();
             long external = context != null ? context.externalNanos() : 0L;
             long internal = Math.max(0L, total - external);
-            int status = status(response, error);
+            int status = status(response, failed);
 
             Tags tags = Tags.of(
                     "method", method(request),
@@ -118,9 +120,9 @@ public class ApiTimingMetricsFilter extends OncePerRequestFilter {
         return OTHER;
     }
 
-    private static int status(HttpServletResponse response, Throwable error) {
+    private static int status(HttpServletResponse response, boolean failed) {
         int status = response.getStatus();
-        if (error != null && status < 400) {
+        if (failed && status < 400) {
             return 500;
         }
         return status;

--- a/src/main/java/it/govpay/common/metrics/ExternalCallMetricsContext.java
+++ b/src/main/java/it/govpay/common/metrics/ExternalCallMetricsContext.java
@@ -27,7 +27,15 @@ public class ExternalCallMetricsContext {
 
     private long externalNanos;
 
-    public void record(long elapsedNanos) {
+    /**
+     * Somma il tempo speso in una chiamata esterna a quello gia' accumulato per la request.
+     * <p>
+     * Il metodo si chiamava {@code record}, identificatore riservato del linguaggio
+     * (SonarCloud java:S6213). La classe e' usata solo all'interno di govpay-common.
+     *
+     * @param elapsedNanos nanosecondi da sommare
+     */
+    public void addExternalNanos(long elapsedNanos) {
         externalNanos += elapsedNanos;
     }
 

--- a/src/main/java/it/govpay/common/metrics/ExternalCallMetricsRecorder.java
+++ b/src/main/java/it/govpay/common/metrics/ExternalCallMetricsRecorder.java
@@ -40,6 +40,8 @@ import io.micrometer.core.instrument.Tags;
  */
 public class ExternalCallMetricsRecorder {
 
+    private static final String OUTCOME_SUCCESS = "success";
+
     private final ObjectProvider<ExternalCallMetricsContext> contextProvider;
     private final MeterRegistry meterRegistry;
 
@@ -51,13 +53,21 @@ public class ExternalCallMetricsRecorder {
 
     public void record(String client, String operation, ExternalCall call) {
         long start = System.nanoTime();
-        String outcome = "success";
+        String outcome = OUTCOME_SUCCESS;
+        // Gli Error non vengono catturati: farlo terrebbe in vita una JVM in stato
+        // irrecuperabile (SonarCloud java:S1181). Il flag intercetta comunque l'uscita
+        // anomala, cosi' la metrica non la registra come successo.
+        boolean completed = false;
         try {
             call.run();
-        } catch (RuntimeException | Error e) {
+            completed = true;
+        } catch (RuntimeException e) {
             outcome = ExternalCallOutcomeRegistry.classify(e);
             throw e;
         } finally {
+            if (!completed && OUTCOME_SUCCESS.equals(outcome)) {
+                outcome = ExternalCallOutcomeRegistry.OUTCOME_ERROR;
+            }
             long elapsed = System.nanoTime() - start;
             recordDuration(client, operation, outcome, elapsed);
         }
@@ -74,7 +84,7 @@ public class ExternalCallMetricsRecorder {
         try {
             ExternalCallMetricsContext context = contextProvider.getIfAvailable();
             if (context != null) {
-                context.record(elapsed);
+                context.addExternalNanos(elapsed);
             }
         } catch (ScopeNotActiveException e) {
             // Chiamata misurata fuori da una request HTTP: resta la metrica del client esterno,

--- a/src/main/java/it/govpay/common/utils/DurationUtils.java
+++ b/src/main/java/it/govpay/common/utils/DurationUtils.java
@@ -53,6 +53,11 @@ import java.util.Objects;
  */
 public final class DurationUtils {
 
+    private static final String MSG_START_NULL = "L'istante iniziale (start) non può essere null";
+    private static final String MSG_END_NULL = "L'istante finale (end) non può essere null";
+    private static final String MSG_ZONE_NULL = "La zona (zone) non può essere null";
+    private static final String MSG_CLOCK_NULL = "L'orologio (clock) non può essere null";
+
     private DurationUtils() {
         // Utility class
     }
@@ -67,9 +72,9 @@ public final class DurationUtils {
      * @throws NullPointerException se uno dei parametri e' null
      */
     public static Duration between(LocalDateTime start, LocalDateTime end, ZoneId zone) {
-        Objects.requireNonNull(start, "start non puo' essere null");
-        Objects.requireNonNull(end, "end non puo' essere null");
-        Objects.requireNonNull(zone, "zone non puo' essere null");
+        Objects.requireNonNull(start, MSG_START_NULL);
+        Objects.requireNonNull(end, MSG_END_NULL);
+        Objects.requireNonNull(zone, MSG_ZONE_NULL);
         return Duration.between(start.atZone(zone), end.atZone(zone));
     }
 
@@ -117,8 +122,8 @@ public final class DurationUtils {
      * @throws NullPointerException se uno dei parametri e' null
      */
     public static Duration since(LocalDateTime start, ZoneId zone) {
-        Objects.requireNonNull(start, "start non puo' essere null");
-        Objects.requireNonNull(zone, "zone non puo' essere null");
+        Objects.requireNonNull(start, MSG_START_NULL);
+        Objects.requireNonNull(zone, MSG_ZONE_NULL);
         return Duration.between(start.atZone(zone), ZonedDateTime.now(zone));
     }
 
@@ -136,8 +141,8 @@ public final class DurationUtils {
      * @throws NullPointerException se uno dei parametri e' null
      */
     public static Duration since(LocalDateTime start, Clock clock) {
-        Objects.requireNonNull(start, "start non puo' essere null");
-        Objects.requireNonNull(clock, "clock non puo' essere null");
+        Objects.requireNonNull(start, MSG_START_NULL);
+        Objects.requireNonNull(clock, MSG_CLOCK_NULL);
         return Duration.between(start.atZone(clock.getZone()).toInstant(), clock.instant());
     }
 }

--- a/src/main/java/it/govpay/common/utils/OffsetDateTimeDeserializer.java
+++ b/src/main/java/it/govpay/common/utils/OffsetDateTimeDeserializer.java
@@ -60,7 +60,7 @@ public class OffsetDateTimeDeserializer extends StdScalarDeserializer<OffsetDate
     /** Default offset for dates without timezone (CET = Central European Time) */
     private static final ZoneOffset DEFAULT_OFFSET = ZoneOffset.ofHoursMinutes(1, 0);
 
-    private transient DateTimeFormatter formatter;
+    private DateTimeFormatter formatter;
 
     /**
      * Flexible formatter that handles:

--- a/src/main/java/it/govpay/common/utils/OffsetDateTimeSerializer.java
+++ b/src/main/java/it/govpay/common/utils/OffsetDateTimeSerializer.java
@@ -46,7 +46,7 @@ public class OffsetDateTimeSerializer extends StdScalarSerializer<OffsetDateTime
 
     private static final long serialVersionUID = 1L;
 
-    private transient DateTimeFormatter formatter;
+    private DateTimeFormatter formatter;
 
     /**
      * Default constructor using standard timestamp format with timezone.

--- a/src/test/java/it/govpay/common/batch/controller/AbstractBatchControllerTest.java
+++ b/src/test/java/it/govpay/common/batch/controller/AbstractBatchControllerTest.java
@@ -43,7 +43,6 @@ import org.springframework.batch.core.job.JobInstance;
 import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.job.parameters.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobExecutionNotRunningException;
-import org.springframework.batch.core.launch.NoSuchJobExecutionException;
 import org.springframework.batch.core.step.StepExecution;
 import org.springframework.batch.core.repository.JobRepository;
 import org.springframework.core.env.Environment;
@@ -247,7 +246,9 @@ class AbstractBatchControllerTest {
         @Test
         @DisplayName("Stop accettato - 202")
         void accepted() throws Exception {
-            when(jobExecutionHelper.stopExecution(42L)).thenReturn(true);
+            JobExecution execution = mock(JobExecution.class);
+            when(jobRepository.getJobExecution(42L)).thenReturn(execution);
+            when(jobExecutionHelper.stopExecution(execution)).thenReturn(true);
 
             ResponseEntity<Object> response = controller.stopExecution(42L);
 
@@ -257,7 +258,10 @@ class AbstractBatchControllerTest {
         @Test
         @DisplayName("Esecuzione non in corso - 409")
         void notRunning() throws Exception {
-            when(jobExecutionHelper.stopExecution(42L)).thenThrow(new JobExecutionNotRunningException("non in corso"));
+            JobExecution execution = mock(JobExecution.class);
+            when(jobRepository.getJobExecution(42L)).thenReturn(execution);
+            when(jobExecutionHelper.stopExecution(execution))
+                    .thenThrow(new JobExecutionNotRunningException("non in corso"));
 
             ResponseEntity<Object> response = controller.stopExecution(42L);
 
@@ -268,12 +272,14 @@ class AbstractBatchControllerTest {
         @Test
         @DisplayName("Esecuzione inesistente - 404")
         void notFound() throws Exception {
-            when(jobExecutionHelper.stopExecution(99L)).thenThrow(new NoSuchJobExecutionException("non trovata"));
+            // Il JobRepository non conosce l'id: 404 gestito senza l'eccezione deprecata
+            when(jobRepository.getJobExecution(99L)).thenReturn(null);
 
             ResponseEntity<Object> response = controller.stopExecution(99L);
 
             assertEquals(404, response.getStatusCode().value());
             assertInstanceOf(Problem.class, response.getBody());
+            verify(jobExecutionHelper, never()).stopExecution(any(JobExecution.class));
         }
     }
 

--- a/src/test/java/it/govpay/common/batch/runner/JobExecutionHelperTest.java
+++ b/src/test/java/it/govpay/common/batch/runner/JobExecutionHelperTest.java
@@ -34,7 +34,6 @@ import org.springframework.batch.core.job.JobExecution;
 import org.springframework.batch.core.job.parameters.JobParameters;
 import org.springframework.batch.core.launch.JobExecutionNotRunningException;
 import org.springframework.batch.core.launch.JobOperator;
-import org.springframework.batch.core.launch.NoSuchJobExecutionException;
 
 import it.govpay.common.batch.runner.JobExecutionHelper.PreExecutionCheckResult;
 import it.govpay.common.batch.runner.JobExecutionHelper.PreExecutionResult;
@@ -187,30 +186,26 @@ class JobExecutionHelperTest {
     }
 
     @Test
-    @DisplayName("stopExecution - delega a JobOperator.stop e ritorna true")
+    @DisplayName("stopExecution - delega a JobOperator.stop(JobExecution) e ritorna true")
     void stopExecution_success() throws Exception {
-        when(jobOperator.stop(42L)).thenReturn(true);
+        JobExecution execution = mock(JobExecution.class);
+        when(execution.getId()).thenReturn(42L);
+        when(jobOperator.stop(execution)).thenReturn(true);
 
-        boolean result = helper.stopExecution(42L);
+        boolean result = helper.stopExecution(execution);
 
         assertTrue(result);
-        verify(jobOperator).stop(42L);
+        verify(jobOperator).stop(execution);
     }
 
     @Test
     @DisplayName("stopExecution - propaga JobExecutionNotRunningException")
     void stopExecution_notRunning() throws Exception {
-        when(jobOperator.stop(42L)).thenThrow(new JobExecutionNotRunningException("non in corso"));
+        JobExecution execution = mock(JobExecution.class);
+        when(execution.getId()).thenReturn(42L);
+        when(jobOperator.stop(execution)).thenThrow(new JobExecutionNotRunningException("non in corso"));
 
-        assertThrows(JobExecutionNotRunningException.class, () -> helper.stopExecution(42L));
-    }
-
-    @Test
-    @DisplayName("stopExecution - propaga NoSuchJobExecutionException")
-    void stopExecution_notFound() throws Exception {
-        when(jobOperator.stop(99L)).thenThrow(new NoSuchJobExecutionException("non trovata"));
-
-        assertThrows(NoSuchJobExecutionException.class, () -> helper.stopExecution(99L));
+        assertThrows(JobExecutionNotRunningException.class, () -> helper.stopExecution(execution));
     }
 
     @Test

--- a/src/test/java/it/govpay/common/metrics/ApiTimingMetricsFilterTest.java
+++ b/src/test/java/it/govpay/common/metrics/ApiTimingMetricsFilterTest.java
@@ -39,7 +39,7 @@ class ApiTimingMetricsFilterTest {
     void recordsApiTimingOnRequestDispatch() throws Exception {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         ExternalCallMetricsContext context = new ExternalCallMetricsContext();
-        context.record(1_000L);
+        context.addExternalNanos(1_000L);
         ApiTimingMetricsFilter filter = new ApiTimingMetricsFilter(provider(context), registry);
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/test");
@@ -57,7 +57,7 @@ class ApiTimingMetricsFilterTest {
     void skipsErrorDispatchToAvoidDoubleCountingSameRequest() throws Exception {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         ExternalCallMetricsContext context = new ExternalCallMetricsContext();
-        context.record(1_000L);
+        context.addExternalNanos(1_000L);
         ApiTimingMetricsFilter filter = new ApiTimingMetricsFilter(provider(context), registry);
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/error");

--- a/src/test/java/it/govpay/common/metrics/ExternalCallMetricsRecorderTest.java
+++ b/src/test/java/it/govpay/common/metrics/ExternalCallMetricsRecorderTest.java
@@ -68,7 +68,7 @@ class ExternalCallMetricsRecorderTest {
         ScopeNotActiveException scopeError = new ScopeNotActiveException(
                 "request", "externalCallMetricsContext", new IllegalStateException("no request"));
         when(context.externalNanos()).thenThrow(scopeError);
-        org.mockito.Mockito.doThrow(scopeError).when(context).record(org.mockito.ArgumentMatchers.anyLong());
+        org.mockito.Mockito.doThrow(scopeError).when(context).addExternalNanos(org.mockito.ArgumentMatchers.anyLong());
 
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         ExternalCallMetricsRecorder recorder = new ExternalCallMetricsRecorder(provider(context), registry);

--- a/src/test/java/it/govpay/common/utils/DurationUtilsTest.java
+++ b/src/test/java/it/govpay/common/utils/DurationUtilsTest.java
@@ -19,7 +19,6 @@
 package it.govpay.common.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -31,7 +30,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -40,139 +38,129 @@ import org.junit.jupiter.api.Test;
  * <p>
  * Riferimenti 2026: passaggio a ora legale domenica 29 marzo (02:00 CET -&gt; 03:00 CEST),
  * ritorno a ora solare domenica 25 ottobre (03:00 CEST -&gt; 02:00 CET).
+ * <p>
+ * I valori attesi sono scritti come costanti esplicite: calcolarli con
+ * {@code Duration.between} sugli stessi {@code LocalDateTime} li confronterebbe con un'altra
+ * istanza dello stesso errore, e i test passerebbero anche con l'utility sbagliata.
  */
 class DurationUtilsTest {
 
     private static final ZoneId ROMA = ZoneId.of("Europe/Rome");
 
-    @Nested
-    @DisplayName("between - transizioni DST")
-    class Between {
+    // Passaggio a ora legale: le lancette saltano da 02:00 a 03:00.
+    // Tra i due istanti locali e' passata un'ora sola; il calcolo naif ne conterebbe due.
+    private static final LocalDateTime ORA_LEGALE_INIZIO = LocalDateTime.of(2026, 3, 29, 1, 30);
+    private static final LocalDateTime ORA_LEGALE_FINE = LocalDateTime.of(2026, 3, 29, 3, 30);
+    private static final Duration ORA_LEGALE_DURATA_REALE = Duration.ofHours(1);
 
-        @Test
-        @DisplayName("passaggio a ora legale: un'ora locale in meno di quella apparente")
-        void oraLegale() {
-            LocalDateTime inizio = LocalDateTime.of(2026, 3, 29, 1, 30);
-            LocalDateTime fine = LocalDateTime.of(2026, 3, 29, 3, 30);
+    // Ritorno a ora solare: le lancette tornano da 03:00 a 02:00.
+    // Tra i due istanti locali sono passate quattro ore; il calcolo naif ne conterebbe tre.
+    private static final LocalDateTime ORA_SOLARE_INIZIO = LocalDateTime.of(2026, 10, 25, 1, 30);
+    private static final LocalDateTime ORA_SOLARE_FINE = LocalDateTime.of(2026, 10, 25, 4, 30);
+    private static final Duration ORA_SOLARE_DURATA_REALE = Duration.ofHours(4);
 
-            Duration durata = DurationUtils.between(inizio, fine, ROMA);
-
-            // Le lancette saltano da 02:00 a 03:00: tra i due istanti e' passata una sola ora
-            assertEquals(Duration.ofHours(1), durata);
-            // Il calcolo naif su LocalDateTime ne conterebbe due
-            assertNotEquals(Duration.between(inizio, fine), durata);
-        }
-
-        @Test
-        @DisplayName("ritorno a ora solare: un'ora locale in piu' di quella apparente")
-        void oraSolare() {
-            LocalDateTime inizio = LocalDateTime.of(2026, 10, 25, 1, 30);
-            LocalDateTime fine = LocalDateTime.of(2026, 10, 25, 4, 30);
-
-            Duration durata = DurationUtils.between(inizio, fine, ROMA);
-
-            // Le lancette tornano da 03:00 a 02:00: sono passate quattro ore, non tre
-            assertEquals(Duration.ofHours(4), durata);
-            assertEquals(Duration.ofHours(3), Duration.between(inizio, fine));
-        }
-
-        @Test
-        @DisplayName("ora ambigua risolta sull'offset precedente, durata mai negativa")
-        void oraAmbigua() {
-            // 02:30 del 25 ottobre esiste due volte: atZone sceglie l'offset dell'ora legale
-            LocalDateTime inizio = LocalDateTime.of(2026, 10, 25, 2, 30);
-            LocalDateTime fine = LocalDateTime.of(2026, 10, 25, 2, 45);
-
-            Duration durata = DurationUtils.between(inizio, fine, ROMA);
-
-            assertEquals(Duration.ofMinutes(15), durata);
-            assertTrue(durata.isPositive() || durata.isZero());
-        }
-
-        @Test
-        @DisplayName("intervallo senza transizioni: identico al calcolo naif")
-        void giornoNormale() {
-            LocalDateTime inizio = LocalDateTime.of(2026, 6, 15, 10, 0);
-            LocalDateTime fine = LocalDateTime.of(2026, 6, 15, 10, 5);
-
-            assertEquals(Duration.ofMinutes(5), DurationUtils.between(inizio, fine, ROMA));
-        }
-
-        @Test
-        @DisplayName("parametri null rifiutati")
-        void parametriNull() {
-            LocalDateTime istante = LocalDateTime.of(2026, 6, 15, 10, 0);
-
-            assertThrows(NullPointerException.class, () -> DurationUtils.between(null, istante, ROMA));
-            assertThrows(NullPointerException.class, () -> DurationUtils.between(istante, null, ROMA));
-            assertThrows(NullPointerException.class, () -> DurationUtils.between(istante, istante, null));
-        }
+    @Test
+    @DisplayName("between - passaggio a ora legale: un'ora reale, non due")
+    void betweenAttraversoOraLegale() {
+        assertEquals(ORA_LEGALE_DURATA_REALE,
+                DurationUtils.between(ORA_LEGALE_INIZIO, ORA_LEGALE_FINE, ROMA));
     }
 
-    @Nested
-    @DisplayName("varianti null-safe")
-    class NullSafe {
-
-        @Test
-        @DisplayName("secondsBetween restituisce null se un estremo manca")
-        void secondsBetween() {
-            LocalDateTime inizio = LocalDateTime.of(2026, 10, 25, 1, 30);
-            LocalDateTime fine = LocalDateTime.of(2026, 10, 25, 4, 30);
-
-            assertEquals(4 * 3600L, DurationUtils.secondsBetween(inizio, fine, ROMA));
-            assertNull(DurationUtils.secondsBetween(null, fine, ROMA));
-            assertNull(DurationUtils.secondsBetween(inizio, null, ROMA));
-        }
-
-        @Test
-        @DisplayName("millisBetweenOrZero azzera se un estremo manca")
-        void millisBetweenOrZero() {
-            LocalDateTime inizio = LocalDateTime.of(2026, 3, 29, 1, 30);
-            LocalDateTime fine = LocalDateTime.of(2026, 3, 29, 3, 30);
-
-            assertEquals(3600_000L, DurationUtils.millisBetweenOrZero(inizio, fine, ROMA));
-            assertEquals(0L, DurationUtils.millisBetweenOrZero(null, fine, ROMA));
-            assertEquals(0L, DurationUtils.millisBetweenOrZero(inizio, null, ROMA));
-        }
+    @Test
+    @DisplayName("between - ritorno a ora solare: quattro ore reali, non tre")
+    void betweenAttraversoOraSolare() {
+        assertEquals(ORA_SOLARE_DURATA_REALE,
+                DurationUtils.between(ORA_SOLARE_INIZIO, ORA_SOLARE_FINE, ROMA));
     }
 
-    @Nested
-    @DisplayName("since")
-    class Since {
+    @Test
+    @DisplayName("between - ora ambigua risolta sull'offset precedente, durata mai negativa")
+    void betweenOraAmbigua() {
+        // 02:30 del 25 ottobre esiste due volte: atZone sceglie l'offset dell'ora legale
+        Duration durata = DurationUtils.between(
+                LocalDateTime.of(2026, 10, 25, 2, 30),
+                LocalDateTime.of(2026, 10, 25, 2, 45),
+                ROMA);
 
-        @Test
-        @DisplayName("con Clock fisso a cavallo del ritorno all'ora solare")
-        void sinceConClockFisso() {
-            // Il clock e' fermo alle 02:00 CET del 25 ottobre 2026, cioe' 01:00 UTC
-            Clock clock = Clock.fixed(Instant.parse("2026-10-25T01:00:00Z"), ROMA);
-            // Ultimo aggiornamento alle 01:30 ora locale, ancora in ora legale: 23:30 UTC del 24
-            LocalDateTime ultimoAggiornamento = LocalDateTime.of(2026, 10, 25, 1, 30);
+        assertEquals(Duration.ofMinutes(15), durata);
+        assertTrue(durata.isPositive());
+    }
 
-            Duration durata = DurationUtils.since(ultimoAggiornamento, clock);
+    @Test
+    @DisplayName("between - intervallo senza transizioni")
+    void betweenGiornoNormale() {
+        assertEquals(Duration.ofMinutes(5), DurationUtils.between(
+                LocalDateTime.of(2026, 6, 15, 10, 0),
+                LocalDateTime.of(2026, 6, 15, 10, 5),
+                ROMA));
+    }
 
-            // Sono passati 90 minuti reali, non 30 come suggerirebbe la differenza delle ore locali
-            assertEquals(90, durata.toMinutes());
-        }
+    @Test
+    @DisplayName("between - parametri null rifiutati")
+    void betweenParametriNull() {
+        LocalDateTime istante = LocalDateTime.of(2026, 6, 15, 10, 0);
 
-        @Test
-        @DisplayName("con ZoneId esplicita restituisce una durata non negativa")
-        void sinceConZone() {
-            Duration durata = DurationUtils.since(LocalDateTime.now(ROMA).minusMinutes(5), ROMA);
+        assertThrows(NullPointerException.class, () -> DurationUtils.between(null, istante, ROMA));
+        assertThrows(NullPointerException.class, () -> DurationUtils.between(istante, null, ROMA));
+        assertThrows(NullPointerException.class, () -> DurationUtils.between(istante, istante, null));
+    }
 
-            assertTrue(durata.toMinutes() >= 4 && durata.toMinutes() <= 6,
-                    "durata inattesa: " + durata);
-        }
+    @Test
+    @DisplayName("secondsBetween - durata reale attraverso la transizione, null se un estremo manca")
+    void secondsBetween() {
+        assertEquals(ORA_SOLARE_DURATA_REALE.getSeconds(),
+                DurationUtils.secondsBetween(ORA_SOLARE_INIZIO, ORA_SOLARE_FINE, ROMA));
+        assertNull(DurationUtils.secondsBetween(null, ORA_SOLARE_FINE, ROMA));
+        assertNull(DurationUtils.secondsBetween(ORA_SOLARE_INIZIO, null, ROMA));
+    }
 
-        @Test
-        @DisplayName("parametri null rifiutati")
-        void parametriNull() {
-            Clock clock = Clock.fixed(Instant.parse("2026-10-25T01:00:00Z"), ROMA);
+    @Test
+    @DisplayName("millisBetweenOrZero - durata reale attraverso la transizione, zero se un estremo manca")
+    void millisBetweenOrZero() {
+        assertEquals(ORA_LEGALE_DURATA_REALE.toMillis(),
+                DurationUtils.millisBetweenOrZero(ORA_LEGALE_INIZIO, ORA_LEGALE_FINE, ROMA));
+        assertEquals(0L, DurationUtils.millisBetweenOrZero(null, ORA_LEGALE_FINE, ROMA));
+        assertEquals(0L, DurationUtils.millisBetweenOrZero(ORA_LEGALE_INIZIO, null, ROMA));
+    }
 
-            assertThrows(NullPointerException.class, () -> DurationUtils.since(null, clock));
-            assertThrows(NullPointerException.class,
-                    () -> DurationUtils.since(LocalDateTime.now(ROMA), (Clock) null));
-            assertThrows(NullPointerException.class,
-                    () -> DurationUtils.since(LocalDateTime.now(ROMA), (ZoneId) null));
-        }
+    @Test
+    @DisplayName("since con Clock fisso a cavallo del ritorno all'ora solare")
+    void sinceConClockFisso() {
+        // Clock fermo alle 02:00 CET del 25 ottobre 2026, cioe' 01:00 UTC
+        Clock clock = Clock.fixed(Instant.parse("2026-10-25T01:00:00Z"), ROMA);
+
+        // Ultimo aggiornamento alle 01:30 ora locale, ancora in ora legale: 23:30 UTC del 24.
+        // Sono passati 90 minuti reali, non i 30 della differenza fra le due ore locali.
+        assertEquals(90, DurationUtils.since(ORA_SOLARE_INIZIO, clock).toMinutes());
+    }
+
+    @Test
+    @DisplayName("since con Clock fisso a cavallo del passaggio a ora legale")
+    void sinceConClockFissoOraLegale() {
+        // Clock fermo alle 03:30 CEST del 29 marzo 2026, cioe' 01:30 UTC
+        Clock clock = Clock.fixed(Instant.parse("2026-03-29T01:30:00Z"), ROMA);
+
+        // Inizio alle 01:30 ora locale (CET, 00:30 UTC): un'ora reale, non due
+        assertEquals(60, DurationUtils.since(ORA_LEGALE_INIZIO, clock).toMinutes());
+    }
+
+    @Test
+    @DisplayName("since con ZoneId esplicita")
+    void sinceConZone() {
+        Duration durata = DurationUtils.since(LocalDateTime.now(ROMA).minusMinutes(5), ROMA);
+
+        assertTrue(durata.toMinutes() >= 4 && durata.toMinutes() <= 6, "durata inattesa: " + durata);
+    }
+
+    @Test
+    @DisplayName("since - parametri null rifiutati")
+    void sinceParametriNull() {
+        Clock clock = Clock.fixed(Instant.parse("2026-10-25T01:00:00Z"), ROMA);
+
+        assertThrows(NullPointerException.class, () -> DurationUtils.since(null, clock));
+        assertThrows(NullPointerException.class,
+                () -> DurationUtils.since(LocalDateTime.now(ROMA), (Clock) null));
+        assertThrows(NullPointerException.class,
+                () -> DurationUtils.since(LocalDateTime.now(ROMA), (ZoneId) null));
     }
 }


### PR DESCRIPTION
Interviene sul report v2 (analisi del 26/08 ore 18:47), che elenca 15 segnalazioni aperte: **2 Bug Blocker, 2 Bug Major, 11 Code Smell**. Ne risolve **14**; l'unica lasciata aperta richiede una decisione condivisa con `govpay-console-api` ed è motivata in fondo.

Prima di intervenire ho recuperato i *flow* di analisi dall'API di SonarCloud e verificato ogni punto che il report marcava come "da verificare": tre delle sue ipotesi si sono rivelate diverse dalla realtà del codice.

## I due Blocker `javabugs:S2259` — stessa causa, non due problemi distinti

**Il primo non era stato risolto dalla PR precedente.** La segnalazione su `GdeCapturingInterceptor` è la stessa (`AZ-FRkM9nmj7TmCjqUYt`), spostata da L147 a L150: la normalizzazione del null introdotta ieri **non è bastata**.

Il flow spiega perché, e vale per entrambe le occorrenze:

```
L144  'responseBody' is defined here
L145  'setResponseBody' is called
      HttpDataHolder L159  Argument 'responseBody' is passed as parameter 'body'
      HttpDataHolder L160  Assuming this condition to be false      <-- body != null
L150  The access that will throw a NullPointerException
```

Il motore esplora il ramo `null` **dentro il metodo chiamato** e retropropaga quel vincolo sull'argomento: da quel punto in poi considera nullo il nostro array, qualunque cosa gli avessimo assegnato prima. Lo stesso schema nel controller, dove `getClusterIdFromExecution(currentExecution)` null-checkeggia il parametro e rende "nulla" `currentExecution` all'accesso successivo.

La correzione, in entrambi i casi, è leggere i valori necessari **prima** di consegnare l'oggetto al metodo che tollera il null:

| File | Prima | Dopo |
|---|---|---|
| `GdeCapturingInterceptor` | `setResponseBody(responseBody)` → poi `responseBody.length` nel log | `int responseBodyLength = responseBody.length` → poi `setResponseBody(...)` |
| `AbstractBatchController` | `getClusterIdFromExecution(currentExecution)` → poi `currentExecution.getId()` | `Long executionId = currentExecution.getId()` → poi `getClusterIdFromExecution(...)` |

Verificato inoltre sui sorgenti di Spring 7.0.8 che `StreamUtils.copyToByteArray` non restituisce mai null: il percorso non è raggiungibile in produzione, ma ora il codice non lo rende nemmeno inferibile.

## I test della correzione temporale — la critica del report era fondata

`DurationUtilsTest` è stato riscritto:

- **`java:S2187`** — la struttura `@Nested` lasciava la classe esterna priva di test eseguibili (l'ipotesi "falso positivo da @Nested" del report era corretta: la suite girava, 604 test). Struttura resa **piatta**: 11 test di primo livello, la segnalazione decade senza bisogno di chiuderla come *Won't fix*.
- **`java:S8700` (2)** — qui il report ha ragione su un punto sostanziale: i valori attesi erano calcolati con `Duration.between` sugli stessi `LocalDateTime`, cioè confrontati con **un'altra istanza dell'errore che l'utility deve correggere**. Ora sono costanti esplicite (`Duration.ofHours(1)`, `Duration.ofHours(4)`), con il ragionamento documentato nel Javadoc della classe di test.
- Aggiunto un test con `Clock` fisso anche sul **passaggio a ora legale** (29/03/2026): prima era coperto solo il ritorno a ora solare.

**`java:S1192`** su `DurationUtils`: messaggi di precondition estratti in costanti, una per parametro, con testo accentato in UTF-8 come suggerito.

## `java:S5738` — API Spring Batch deprecate per la rimozione

Il report non sapeva quali fossero. Verificato sui sorgenti di `spring-batch-core` 6.0.4:

- `JobOperator.stop(long)` — `@Deprecated(since = "6.0", forRemoval = true)`, sostituito da `stop(JobExecution)`
- `NoSuchJobExecutionException` — `@Deprecated(since = "6.0", forRemoval = true)`, **rimozione dichiarata per la 6.2**, senza sostituto
- `JobExecutionNotRunningException` — **non** deprecata (il report la indicava come tale)

Migrazione: `JobExecutionHelper.stopExecution` accetta una `JobExecution` e usa `stop(JobExecution)`; `AbstractBatchController` risolve l'id tramite `JobRepository.getJobExecution(long)` e restituisce il 404 esplicitamente, senza l'eccezione destinata a sparire. **Le semantiche HTTP dell'endpoint restano identiche** (202 / 409 / 404, sempre in formato `Problem`).

Cambia la firma di un metodo pubblico della libreria, ma **nessun consumer noto lo invoca**: `govpay-console-api` chiama l'endpoint REST (`OperazioneBatchClient.stopExecution(url, id)`), non il metodo Java.

## `java:S1181` — `catch (Error)` nelle metriche: il rischio reale era diverso

Il report descriveva il rischio di "mantenere in vita una JVM in stato irrecuperabile". In realtà entrambi i blocchi **rilanciavano** (`throw e`): l'`Error` si propagava già, e la cattura serviva solo a classificare l'esito della metrica.

La correzione elimina comunque la cattura e ottiene di più: l'uscita anomala è rilevata con un flag nel `finally`, quindi **un `Error` non viene più contato come `success`** — prima nel filtro sì, se il `catch` non lo intercettava. Propagazione inalterata, osservabilità più corretta.

## `java:S6213`, `java:S2065`

- `ExternalCallMetricsContext.record()` → `addExternalNanos()`. Verificato con grep su tutti i repo GovPay: la classe è usata solo dentro `govpay-common`.
- Rimosso `transient` dai formatter di `OffsetDateTimeSerializer`/`Deserializer`, che non implementano `Serializable`.

## Non risolta: `ExternalCallMetricsRecorder.record()` (#12)

Il report la dava come impatto "contenuto, da verificare". **La verifica dice il contrario**: il metodo è sovrascritto da un consumer.

```java
// govpay-console-api — NoopExternalCallMetricsRecorder
public class NoopExternalCallMetricsRecorder extends ExternalCallMetricsRecorder {
    @Override
    public void record(String client, String operation, ExternalCall call) { call.run(); }
}
```

Rinominarlo qui rompe la compilazione di `govpay-console-api`, ed è quindi una modifica di contratto da fare nei due moduli contestualmente (BP-API-2). Va decisa, non fatta di sorpresa in questa PR.

## Verifiche

**604 test, 0 failure.** Checklist §5 del report, tutta verde e verificata con `grep` indipendentemente da Sonar:

| Punto | Esito |
|---|---|
| Nessun `Duration.between`/`ChronoUnit.between` su tipi locali, **test inclusi** | ✔ (solo dentro `DurationUtils`, su `ZonedDateTime`/`Instant`) |
| Nessun `.now()` privo di `ZoneId`/`Clock` in `src/main` | ✔ |
| Nessuna API `@Deprecated(forRemoval = true)` | ✔ |
| Nessun `catch` di `Error`/`Throwable` | ✔ |
| Esiste ed esegue almeno un test su una transizione DST | ✔ (ora entrambe le transizioni) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)